### PR TITLE
feat: add requireMention config for group chats

### DIFF
--- a/src/receive.ts
+++ b/src/receive.ts
@@ -132,7 +132,13 @@ async function handleIncomingMessage(
   if (chatType === "group") {
     const mentions = Array.isArray(message.mentions) ? (message.mentions as unknown[]) : [];
     text = text.replace(/@_user_\d+\s*/g, "").trim();
-    if (!text || !shouldRespondInGroup(text, mentions, ctx.botNames)) return;
+    if (!text) return;
+
+    // Check per-group and account-level requireMention config
+    const groupCfg = ctx.account.config.groups?.[chatId];
+    const requireMention = groupCfg?.requireMention ?? ctx.account.config.requireMention ?? true;
+
+    if (requireMention && !shouldRespondInGroup(text, mentions, ctx.botNames)) return;
   }
 
   ctx.statusSink?.({ lastInboundAt: Date.now() });

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,16 @@
  * Feishu channel plugin — type definitions.
  */
 
+/** Per-group configuration. */
+export type FeishuGroupConfig = {
+  /**
+   * When true (default), only respond when the bot is @-mentioned or
+   * the message matches the smart group filter heuristics.
+   * Set to false to receive and respond to ALL messages in this group.
+   */
+  requireMention?: boolean;
+};
+
 /** Per-account configuration stored in clawdbot.json channels.feishu */
 export type FeishuAccountConfig = {
   /** Optional display name for this account. */
@@ -22,6 +32,16 @@ export type FeishuAccountConfig = {
   botNames?: string[];
   /** Max inbound media size in MB. */
   mediaMaxMb?: number;
+  /**
+   * Per-group overrides keyed by Feishu chat_id.
+   * Example: `{ "oc_xxx": { "requireMention": false } }`
+   */
+  groups?: Record<string, FeishuGroupConfig>;
+  /**
+   * Default requireMention for all groups not listed in `groups`.
+   * Default: true (use smart filter / require @-mention).
+   */
+  requireMention?: boolean;
 };
 
 /** Top-level Feishu config section (channels.feishu). */


### PR DESCRIPTION
## Problem

In group chats, the plugin always applies the smart group filter, which only passes through messages that contain @-mentions, question marks, question words, or Chinese request verbs. There is no way to configure the bot to listen to all messages in a group.

## Solution

Add a requireMention config option at two levels:

- **Per-group:** channels.feishu.groups[chatId].requireMention
- **Account-wide default:** channels.feishu.requireMention

When set to false, the bot receives and responds to all messages without needing an @-mention or matching the smart filter.

### Config example

```json
{
  "channels": {
    "feishu": {
      "requireMention": false,
      "groups": {
        "oc_specific_chat": { "requireMention": false }
      }
    }
  }
}
```

### Priority
1. Per-group groups[chatId].requireMention
2. Account-level requireMention
3. Default: true (existing behavior unchanged)

## Changes
- src/types.ts: Added FeishuGroupConfig type, groups and requireMention fields
- src/receive.ts: Check config before applying shouldRespondInGroup filter

Builds cleanly, no breaking changes.