### PR TITLE
Support multiple Feishu ID types in message sending

### DIFF
--- a/src/send.ts
+++ b/src/send.ts
@@ -14,6 +14,13 @@ import {
   uploadImage,
 } from "./media.js";
 
+/** Resolve the correct receive_id_type based on ID prefix. */
+function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "union_id" {
+  if (id.startsWith("ou_")) return "open_id";
+  if (id.startsWith("on_")) return "union_id";
+  return "chat_id";
+}
+
 /**
  * Send a text message to a Feishu chat.
  */
@@ -40,7 +47,7 @@ export async function sendTextMessage(
     }
 
     const res = await client.im.message.create({
-      params: { receive_id_type: "chat_id" },
+      params: { receive_id_type: resolveReceiveIdType(chatId.trim()) },
       data: {
         receive_id: chatId.trim(),
         msg_type: "text",
@@ -113,7 +120,7 @@ export async function sendMediaMessage(
       });
     } else {
       await client.im.message.create({
-        params: { receive_id_type: "chat_id" },
+        params: { receive_id_type: resolveReceiveIdType(chatId.trim()) },
         data: { receive_id: chatId.trim(), content, msg_type: msgType },
       });
     }
@@ -121,7 +128,7 @@ export async function sendMediaMessage(
     // Send accompanying text as separate message if provided
     if (text?.trim()) {
       await client.im.message.create({
-        params: { receive_id_type: "chat_id" },
+        params: { receive_id_type: resolveReceiveIdType(chatId.trim()) },
         data: {
           receive_id: chatId.trim(),
           content: JSON.stringify({ text }),
@@ -136,7 +143,7 @@ export async function sendMediaMessage(
     try {
       const fallbackText = text ? `${text}\n${mediaUrl}` : mediaUrl;
       const res = await client.im.message.create({
-        params: { receive_id_type: "chat_id" },
+        params: { receive_id_type: resolveReceiveIdType(chatId.trim()) },
         data: {
           receive_id: chatId.trim(),
           content: JSON.stringify({ text: fallbackText }),


### PR DESCRIPTION
## Summary
This PR adds support for sending messages to different Feishu ID types (open_id, union_id, and chat_id) by automatically detecting the ID type based on its prefix, rather than hardcoding "chat_id" for all messages.

## Key Changes
- Added `resolveReceiveIdType()` helper function that determines the correct `receive_id_type` parameter based on ID prefix:
  - `ou_` prefix → `open_id`
  - `on_` prefix → `union_id`
  - Default → `chat_id`
- Updated all message sending calls to use `resolveReceiveIdType()` instead of hardcoded `"chat_id"`:
  - `sendTextMessage()` - 1 call updated
  - `sendMediaMessage()` - 3 calls updated (media creation, accompanying text, and fallback text)

## Implementation Details
The ID type resolution is performed on the trimmed `chatId` value to ensure consistent behavior across all message sending operations. This allows the API to correctly route messages to users identified by different ID types without requiring callers to specify the ID type explicitly.

https://claude.ai/code/session_01HsorP6rEcfk82E5LXEJSkz